### PR TITLE
filter targets before api call

### DIFF
--- a/anki_util.py
+++ b/anki_util.py
@@ -8,97 +8,63 @@ from . import yomitan_api
 
 # https://github.com/wikidattica/reversoanki/pull/1/commits/62f0c9145a5ef7b2bde1dc6dfd5f23a53daac4d0
 # targets is a list of tuples in the format (field, handlebar, should_replace)
-def backfill_notes(col, note_ids, expression_field, reading_field, targets):
-    audio_targets = [t for t in targets if "audio" in t[1]]
-    other_targets = [t for t in targets if "audio" not in t[1]]
-
-    # split audio from other handlebars
-    other_handlebars = [h for t in other_targets for h in t[1]]
-    audio_target_handlebars = [h for t in audio_targets for h in t[1]]
-
-    logger.log.info(f"targets: {other_targets}")
-    logger.log.info(f"audio targets: {audio_targets}")
-    logger.log.info(f"target handlebars: {other_handlebars}")
-    logger.log.info(f"audio target handlebars: {audio_target_handlebars}")
-
+def backfill_notes(col, note_ids, expression_field, reading_field, handlebars, targets):
+    logger.log.info(handlebars)
+    logger.log.info(targets)
     notes = []
     for nid in note_ids:
         note = col.get_note(nid)
 
         if not expression_field in note:
             continue
-
+        
         reading = note[reading_field] if reading_field else None
+        api_request = yomitan_api.request_handlebar(note[expression_field].strip(), reading, handlebars)
+        if not api_request:
+            logger.log.error(f"api request failed: {note[expression_field]} {reading} {handlebars}")
+            continue
+
+        api_fields = api_request.get("fields")
+        if not api_fields:
+            logger.log.error(f"api request empty: {note[expression_field]} {reading} {handlebars}")
+            continue
+
         note_updated = False
+        for t in targets:
+            field = t[0]
+            handlebar = t[1]
+            should_replace = t[2]
 
-        if other_handlebars:
-            api_request = yomitan_api.request_handlebar(note[expression_field].strip(), reading, other_handlebars)
-
-            if not api_request:
-                logger.log.error(f"api request failed: {note[expression_field]} {reading} {other_handlebars}")
-                continue
-
-            api_fields = api_request.get("fields")
-            if not api_fields:
-                logger.log.error(f"api request empty: {note[expression_field]} {reading} {other_handlebars}")
-                continue
-
-            for field, handlebar, should_replace in other_targets:
-                if not field in note:
-                    logger.log.error(f"{field} does not exist in notetype")
-                    continue
-
-                if should_replace or not note[field].strip():
-                    data = get_data_from_reading(api_fields, handlebar, reading)
-                    if not data:
-                        logger.log.info(f"skipping {field} for {note[expression_field]}, api data empty")
-                        continue
-
-                    # checks if handlebar data contains filename and writes it to anki if present
-                    dictionary_media = api_request.get("dictionaryMedia", [])
-                    for file in dictionary_media:
-                        filename = file.get("ankiFilename")
-                        if filename in data:
-                            write_media(file)
-                        
-                    note[field] = data
-                    note_updated = True
-                else:
-                    logger.log.info(f"skipping {field} for {note[expression_field]}, {field} not empty")
-
-        # we are only requesting audio if necessary (if current is empty OR if replace is true), this fixes requesting audio for each entry unconditionally
-        for field, handlebar, should_replace in audio_targets:
             if not field in note:
                 logger.log.error(f"{field} does not exist in notetype")
                 continue
 
-            if should_replace or not note[field].strip():
-                audio_api_request = yomitan_api.request_handlebar(note[expression_field].strip(), reading, audio_target_handlebars)
-
-                if not audio_api_request:
-                    logger.log.info(f"skipping {field} for {note[expression_field]}, api data empty")
-                    continue
-
-                audio_api_fields = audio_api_request.get("fields")
-                if not audio_api_fields:
-                    logger.log.error(f"api request failed: {note[expression_field]} {reading} {audio_target_handlebars}")
-                    continue
-                
-                data = get_data_from_reading(audio_api_fields, handlebar, reading)
+            current = note[field].strip()
+            if should_replace or not current:
+                data = get_data_from_reading(api_fields, handlebar, reading)
                 if not data:
                     logger.log.info(f"skipping {field} for {note[expression_field]}, api data empty")
                     continue
-                
-                audio_media = audio_api_request.get("audioMedia", [])
+
+                # checks if handlebar data contains filename and writes it to anki if present
+                dictionary_media = api_request.get("dictionaryMedia", [])
+                for file in dictionary_media:
+                    filename = file.get("ankiFilename")
+                    if filename in data:
+                        write_media(file)
+                            
+                audio_media = api_request.get("audioMedia", [])
                 for file in audio_media:
-                    if file.get("ankiFilename") in data:
+                    filename = file.get("ankiFilename")
+                    # if audio handlebar is requested, handlebar data contains the relevant audio filename, write only that file
+                    if filename in data:
                         write_media(file)
                         break
-                
+                    
                 note[field] = data
                 note_updated = True
             else:
-                logger.log.info(f"skipping {field} for {note[expression_field]}, {field} not empty")
+                logger.log.info(f"skipping {field} for {note[expression_field]}, current {field} not empty")
 
         if note_updated:
             notes.append(note)

--- a/browser.py
+++ b/browser.py
@@ -164,7 +164,7 @@ class BrowserBackfill:
 
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, handlebars, [(field, handlebars, should_replace)])
+                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, [(field, handlebars, should_replace)])
             )
             
             op.success(anki_util.on_success).run_in_background()
@@ -172,7 +172,6 @@ class BrowserBackfill:
         def _run_preset(self):
             expression_field = self.expression_field.currentText()
             reading_field = self.reading_field.currentText()
-            handlebars = []
             target_tuples = []
 
             try:
@@ -183,7 +182,6 @@ class BrowserBackfill:
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
                         should_replace = settings.get("replace")
-                        handlebars.extend(handlebar)
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
@@ -200,7 +198,7 @@ class BrowserBackfill:
 
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, handlebars, target_tuples)
+                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, target_tuples)
             )
             
             op.success(anki_util.on_success).run_in_background()

--- a/browser.py
+++ b/browser.py
@@ -164,7 +164,7 @@ class BrowserBackfill:
 
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, [(field, handlebars, should_replace)])
+                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, handlebars, [(field, handlebars, should_replace)])
             )
             
             op.success(anki_util.on_success).run_in_background()
@@ -172,6 +172,7 @@ class BrowserBackfill:
         def _run_preset(self):
             expression_field = self.expression_field.currentText()
             reading_field = self.reading_field.currentText()
+            handlebars = []
             target_tuples = []
 
             try:
@@ -182,6 +183,7 @@ class BrowserBackfill:
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
                         should_replace = settings.get("replace")
+                        handlebars.extend(handlebar)
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
@@ -198,7 +200,7 @@ class BrowserBackfill:
 
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, target_tuples)
+                op = lambda col: anki_util.backfill_notes(col, self.note_ids, expression_field, reading_field, handlebars, target_tuples)
             )
             
             op.success(anki_util.on_success).run_in_background()

--- a/tools.py
+++ b/tools.py
@@ -155,10 +155,9 @@ class ToolsBackfill:
             should_replace = self.replace.isChecked()
             
             note_ids = mw.col.db.list("SELECT DISTINCT nid FROM cards WHERE did = ?", deck_id)
-            t = (field, handlebars, should_replace)    
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, handlebars, [t])
+                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, [(field, handlebars, should_replace)])
             )
             
             op.success(anki_util.on_success).run_in_background()
@@ -167,7 +166,6 @@ class ToolsBackfill:
             deck_id = self.decks.currentData()
             expression_field = self.expression_field.currentText()
             reading_field = self.reading_field.currentText()
-            handlebars = []
             target_tuples = []
             try:
                 path = os.path.join(anki_util.get_user_files_dir(), self.preset.currentText())
@@ -177,7 +175,6 @@ class ToolsBackfill:
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
                         should_replace = settings.get("replace")
-                        handlebars.extend(handlebar)
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
@@ -195,7 +192,7 @@ class ToolsBackfill:
             note_ids = mw.col.db.list("SELECT DISTINCT nid FROM cards WHERE did = ?", deck_id)
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, handlebars, target_tuples)
+                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, target_tuples)
             )
             
             op.success(anki_util.on_success).run_in_background()

--- a/tools.py
+++ b/tools.py
@@ -155,9 +155,10 @@ class ToolsBackfill:
             should_replace = self.replace.isChecked()
             
             note_ids = mw.col.db.list("SELECT DISTINCT nid FROM cards WHERE did = ?", deck_id)
+            t = (field, handlebars, should_replace)    
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, [(field, handlebars, should_replace)])
+                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, handlebars, [t])
             )
             
             op.success(anki_util.on_success).run_in_background()
@@ -166,6 +167,7 @@ class ToolsBackfill:
             deck_id = self.decks.currentData()
             expression_field = self.expression_field.currentText()
             reading_field = self.reading_field.currentText()
+            handlebars = []
             target_tuples = []
             try:
                 path = os.path.join(anki_util.get_user_files_dir(), self.preset.currentText())
@@ -175,6 +177,7 @@ class ToolsBackfill:
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
                         should_replace = settings.get("replace")
+                        handlebars.extend(handlebar)
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
@@ -192,7 +195,7 @@ class ToolsBackfill:
             note_ids = mw.col.db.list("SELECT DISTINCT nid FROM cards WHERE did = ?", deck_id)
             op = CollectionOp(
                 parent = mw,
-                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, target_tuples)
+                op = lambda col: anki_util.backfill_notes(col, note_ids, expression_field, reading_field, handlebars, target_tuples)
             )
             
             op.success(anki_util.on_success).run_in_background()


### PR DESCRIPTION
~~The main bottleneck of the api request is the `audio` handlebar. Currently if the audio handlebar is requested, it is requested for each entry * max_entries, regardless of the value of `is_replace`. For a deck with 2000 cards, of which 30 have empty audio fields, a max_entries value of 2, and if no audio sources are configured in Yomitan, this took longer than it took me to write the optimization. This cuts it down to one minute.~~

While implementing this I noticed you could just cycle through the targets once, check which targets actually need updating and then only request and update those. This is a lot less complex.