### PR TITLE
validate types of preset keys and catch timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Default: `127.0.0.1`
 
 Default: `19633`
 
+`yomitan_api_timeout`
+
+Default: `10`
+
 ## Issues
 If you're having issues updating please see [this](https://github.com/Manhhao/backfill-anki-yomitan/issues/16).
 

--- a/README.md
+++ b/README.md
@@ -30,25 +30,27 @@ Make sure your Browser is running and the API is working.
 Changes can be undone with `Edit -> Undo` or with `CTRL + Z`.
 
 ## Presets
-You can backfill multiple fields using a .json preset. Presets are stored in the `user_files` folder in the addon directory. An example can be found [here](https://github.com/Manhhao/backfill-anki-yomitan/tree/main/user_files/lapis.json).
+You can backfill multiple fields using a `.json` preset. Presets are stored in the `user_files` folder in the addon directory. An example for [Lapis](https://github.com/donkuri/lapis?tab=readme-ov-file#how-to-use-lapis) is included and can be found [here](https://github.com/Manhhao/backfill-anki-yomitan/tree/main/user_files/lapis.json).
 
 Format:
 ```
 {
     "targets": {
         "FieldName": {
-            "handlebar": "handlebar",
-            "replace": "true"
+            "handlebar": "{handlebar}",
+            "replace": true
         },
         "FieldName2": {
-            "handlebar": "handlebar2,handlebar3",
-            "replace": "false"
+            "handlebar": "{handlebar2},{handlebar3}",
+            "replace": false
         },
         ...
     }
 }
 ```
 `handlebar` and `replace` behave identically to above.
+
+Make sure every handlebar in the preset is a valid handlebar in Yomitan. Otherwise backfilling will fail, because all handlebars are requested in a single API call. For the included `Lapis` preset, this means adjusting the `MainDefinition` handlebar to the one matching your preferred dictionary.
 
 ## Config
 
@@ -75,11 +77,11 @@ Default: `127.0.0.1`
 Default: `19633`
 
 ## Issues
-If you're having issues updating please see [this](https://github.com/Manhhao/backfill-anki-yomitan/issues/16)
+If you're having issues updating please see [this](https://github.com/Manhhao/backfill-anki-yomitan/issues/16).
 
-If you're backfilling audio, please be aware that retrieving audio, depending on the audio sources configured in Yomitan, can be quite slow.
+If you're backfilling audio, please be aware that retrieving audio, depending on the audio sources configured in Yomitan, can be quite slow. You can reduce the time by decreasing `max_entries` in the config.
 
-If you encounter any issues, please report them on GitHub or in the add-on's TMW `#resources-sharing` thread. Please attach the log file `backfill-log.log`, which can be found in the add-on's `user_files` directory.
+If you encounter any issues, please report them on GitHub or in the add-on's TMW `#resources-sharing` thread. Please attach the `backfill-log.log` file, which can be found in the add-on's `user_files` directory.
 
 ## Screenshot
 ![screenshot](https://github.com/Manhhao/backfill-anki-yomitan/blob/main/screenshot/image.png?raw=true)

--- a/browser.py
+++ b/browser.py
@@ -183,15 +183,25 @@ class BrowserBackfill:
                     targets = preset.get("targets")
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
+                        if not handlebar:
+                            logger.log.error(f"handlebar for '{field}' empty in '{self.preset.currentText()}'")
+                            showWarning(f"Handlebar for '{field}' should not be empty.<br>Please edit your preset file.")
+                            return
+
                         should_replace = settings.get("replace")
+                        if not isinstance(should_replace, bool):
+                            logger.log.error(f"'replace' for '{field}' not boolean in '{self.preset.currentText()}'")
+                            showWarning(f"'replace' for '{field}' must be boolean ('true' or 'false', without quotes).<br>Please edit your preset file.")
+                            return
+
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
-                showWarning("json: The selected .json file contains errors.<br>Check the log for more information.")
+                showWarning(f"Preset '{field}' contains errors.<br>Check the log for more information.")
                 return
             except AttributeError as e:
                 logger.log.error(e)
-                showWarning("json: One or more Field(s) are missing keys (handlebar or replace).")
+                showWarning(f"Preset '{field}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
                 return
             except Exception as e:
                 logger.log.error(e)

--- a/browser.py
+++ b/browser.py
@@ -197,11 +197,11 @@ class BrowserBackfill:
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
-                showWarning(f"Preset '{field}' contains errors.<br>Check the log for more information.")
+                showWarning(f"Preset '{self.preset.currentText()}' contains errors.<br>Check the log for more information.")
                 return
             except AttributeError as e:
                 logger.log.error(e)
-                showWarning(f"Preset '{field}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
+                showWarning(f"Preset '{self.preset.currentText()}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
                 return
             except Exception as e:
                 logger.log.error(e)

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
     "max_entries": 4,
     "reading_handlebar": "reading",
     "yomitan_api_ip": "127.0.0.1",
-    "yomitan_api_port": 19633
+    "yomitan_api_port": 19633,
+    "yomitan_api_timeout": 10
 }

--- a/tools.py
+++ b/tools.py
@@ -175,15 +175,25 @@ class ToolsBackfill:
                     targets = preset.get("targets")
                     for field, settings in targets.items():
                         handlebar = [p.lstrip("{").rstrip("}") for p in settings.get("handlebar").split(",") if p.strip()]
+                        if not handlebar:
+                            logger.log.error(f"handlebar for '{field}' empty in '{self.preset.currentText()}'")
+                            showWarning(f"Handlebar for '{field}' should not be empty.<br>Please edit your preset file.")
+                            return
+
                         should_replace = settings.get("replace")
+                        if not isinstance(should_replace, bool):
+                            logger.log.error(f"'replace' for '{field}' not boolean in '{self.preset.currentText()}'")
+                            showWarning(f"'replace' for '{field}' must be boolean ('true' or 'false', without quotes).<br>Please edit your preset file.")
+                            return
+
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
-                showWarning("json: The selected .json file contains errors.<br>Check the log for more information.")
+                showWarning(f"Preset '{field}' contains errors.<br>Check the log for more information.")
                 return
             except AttributeError as e:
                 logger.log.error(e)
-                showWarning("json: Preset file is missing key (targets, handlebar or replace).")
+                showWarning(f"Preset '{field}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
                 return
             except Exception as e:
                 logger.log.error(e)

--- a/tools.py
+++ b/tools.py
@@ -189,11 +189,11 @@ class ToolsBackfill:
                         target_tuples.append((field, handlebar, should_replace))
             except json.JSONDecodeError as e:
                 logger.log.error(e.msg)
-                showWarning(f"Preset '{field}' contains errors.<br>Check the log for more information.")
+                showWarning(f"Preset '{self.preset.currentText()}' contains errors.<br>Check the log for more information.")
                 return
             except AttributeError as e:
                 logger.log.error(e)
-                showWarning(f"Preset '{field}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
+                showWarning(f"Preset '{self.preset.currentText()}' is missing key (targets, handlebar or replace).<br>Check the log for more information.")
                 return
             except Exception as e:
                 logger.log.error(e)

--- a/user_files/lapis.json
+++ b/user_files/lapis.json
@@ -2,31 +2,31 @@
     "targets": {
         "ExpressionFurigana": {
             "handlebar": "{furigana-plain}",
-            "replace": true
+            "replace": false
         },
         "MainDefinition": {
             "handlebar": "{single-glossary-jmdict-2025-08-08}",
-            "replace": true
+            "replace": false
         },
         "Glossary": {
             "handlebar": "{glossary}",
-            "replace": true
+            "replace": false
         },
         "PitchPosition": {
             "handlebar": "{pitch-accent-positions}",
-            "replace": true
+            "replace": false
         },
         "PitchCategories": {
             "handlebar": "{pitch-accent-categories}",
-            "replace": true
+            "replace": false
         },
         "Frequency": {
             "handlebar": "{frequencies}",
-            "replace": true
+            "replace": false
         },
         "FreqSort": {
             "handlebar": "{frequency-harmonic-rank}",
-            "replace": true
+            "replace": false
         }
     }
 }

--- a/yomitan_api.py
+++ b/yomitan_api.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import urllib
 from aqt import mw
 from . import logger
@@ -50,7 +51,11 @@ def request_handlebar(expression, reading, handlebars):
             logger.log.error(f"http 500: request using {markers}")
             return None
         else:
+            logger.log.error(e)
             raise
+    except socket.timeout:
+        logger.log.error(f"request using '{markers}' timed out for '{expression}'")
+        return None
     except URLError as e:
         logger.log.error(e.reason)
         raise ConnectionRefusedError(f"Request to Yomitan API failed: {e.reason}")

--- a/yomitan_api.py
+++ b/yomitan_api.py
@@ -16,11 +16,13 @@ def read_config():
     global request_url
     global max_entries
     global reading_handlebar
+    global request_timeout
     cfg = mw.addonManager.getConfig(__name__)
 
     request_url = f"http://{cfg['yomitan_api_ip']}:{cfg['yomitan_api_port']}"
     max_entries = cfg["max_entries"]
     reading_handlebar = cfg["reading_handlebar"]
+    request_timeout = cfg["yomitan_api_timeout"]
 
 # https://github.com/Kuuuube/yomitan-api/blob/master/docs/api_paths/ankiFields.md
 def request_handlebar(expression, reading, handlebars):


### PR DESCRIPTION
Mainly adds validity checks for each 'handlebar' and 'replace' in preset files and catches errors if there are any. Also stops timeouts from cancelling backfilling for whole batch.

Also addresses a bit of stuff in the README:
- Remove quotes from replace key in format example.
- Mention Lapis preset being included already. Require user to edit `MainDefinition` to their own preferred dictionary.
- Require all handlebars in preset to be valid handlebars.

Adjusted the example Lapis preset to not replace every field.
