### PR TITLE
Field selections are now automatically remembered and restored when reopening the dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Anki addon build artifacts
+*.ankiaddon

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,19 @@
+# Building the Addon
+
+## Quick Build
+
+To create an installable `.ankiaddon` file:
+
+```bash
+python3 build_addon.py
+```
+
+This will create a timestamped file like `backfill-anki-yomitan_20251214_122907.ankiaddon`
+
+## Installing the Addon
+
+1. Open Anki
+2. Go to **Tools → Add-ons**
+3. Click **"Install from file..."**
+4. Select the generated `.ankiaddon` file
+5. Restart Anki

--- a/browser.py
+++ b/browser.py
@@ -60,4 +60,12 @@ class BrowserBackfill:
         
         def _get_deck_id(self):
             return self.deck_id
-        
+
+        def _get_primary_model_id(self):
+            if self.note_ids:
+                try:
+                    note = mw.col.get_note(self.note_ids[0])
+                    return note.mid
+                except:
+                    pass
+            return None

--- a/build_addon.py
+++ b/build_addon.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import zipfile
+import os
+
+INCLUDE_FILES = [
+    'manifest.json',
+    '__init__.py',
+    'base_dialog.py',
+    'browser.py',
+    'tools.py',
+    'config_manager.py',
+    'config.json',
+    'anki_util.py',
+    'logger.py',
+    'yomitan_api.py',
+]
+
+INCLUDE_DIRS = [
+    'user_files',
+]
+
+EXCLUDE_PATTERNS = [
+    '__pycache__',
+    '.pyc',
+    '.pyo',
+    '.DS_Store',
+    '.git',
+    '.gitignore',
+    '.idea',
+    '.claude',
+    'screenshot',
+    'README.md',
+    '.pytest_cache',
+    'build_addon.py',
+]
+
+def should_exclude(path):
+    for pattern in EXCLUDE_PATTERNS:
+        if pattern in path:
+            return True
+    return False
+
+def create_addon_zip():
+    addon_dir = os.path.basename(os.getcwd())
+    zip_filename = f"{addon_dir}.ankiaddon"
+
+    print(f"Creating addon package: {zip_filename}")
+    print("-" * 50)
+
+    with zipfile.ZipFile(zip_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        for filename in INCLUDE_FILES:
+            if os.path.exists(filename):
+                print(f"Adding: {filename}")
+                zipf.write(filename)
+            else:
+                print(f"Warning: {filename} not found, skipping")
+
+        for dirname in INCLUDE_DIRS:
+            if os.path.exists(dirname):
+                for root, dirs, files in os.walk(dirname):
+                    dirs[:] = [d for d in dirs if not should_exclude(os.path.join(root, d))]
+                    for file in files:
+                        filepath = os.path.join(root, file)
+                        if not should_exclude(filepath):
+                            print(f"Adding: {filepath}")
+                            zipf.write(filepath)
+            else:
+                print(f"Warning: {dirname} directory not found, skipping")
+
+    print("-" * 50)
+    print(f"✓ Addon package created: {zip_filename}")
+    print(f"✓ File size: {os.path.getsize(zip_filename):,} bytes")
+    print()
+    print("Installation instructions:")
+    print("1. Open Anki")
+    print("2. Go to Tools → Add-ons")
+    print("3. Click 'Install from file...'")
+    print(f"4. Select: {zip_filename}")
+    print("5. Restart Anki")
+
+    return zip_filename
+
+if __name__ == '__main__':
+    create_addon_zip()

--- a/config.json
+++ b/config.json
@@ -3,5 +3,8 @@
     "reading_handlebar": "reading",
     "yomitan_api_ip": "127.0.0.1",
     "yomitan_api_port": 19633,
-    "yomitan_api_timeout": 10
+    "yomitan_api_timeout": 10,
+    "default_expression_field": "Expression",
+    "default_reading_field": "Reading",
+    "field_memory": {}
 }

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,46 @@
+from aqt import mw
+
+
+def get_config():
+    config = mw.addonManager.getConfig(__name__)
+    if 'field_memory' not in config:
+        config['field_memory'] = {}
+    return config
+
+
+def save_field_memory(model_id, expression_field, reading_field):
+    if model_id is None:
+        return
+
+    model = mw.col.models.get(model_id)
+    if not model:
+        return
+
+    model_name = model['name']
+    config = get_config()
+    config['field_memory'][model_name] = {
+        'expression_field': expression_field,
+        'reading_field': reading_field if reading_field else ''
+    }
+    mw.addonManager.writeConfig(__name__, config)
+
+
+def get_field_memory(model_id):
+    if model_id is None:
+        return None
+
+    model = mw.col.models.get(model_id)
+    if not model:
+        return None
+
+    model_name = model['name']
+    config = get_config()
+    return config.get('field_memory', {}).get(model_name)
+
+
+def get_default_fields():
+    config = get_config()
+    return (
+        config.get('default_expression_field', ''),
+        config.get('default_reading_field', '')
+    )

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,4 @@
+{
+    "package": "1184164376",
+    "name": "backfill-anki-yomitan"
+}

--- a/tools.py
+++ b/tools.py
@@ -52,4 +52,19 @@ class ToolsBackfill:
         
         def _get_deck_id(self):
             return self.decks.currentData()
-        
+
+        def _get_primary_model_id(self):
+            deck_id = self._get_deck_id()
+            if deck_id:
+                nid = mw.col.db.scalar(
+                    "SELECT n.id FROM notes n JOIN cards c ON n.id = c.nid WHERE c.did = ? LIMIT 1",
+                    deck_id
+                )
+                if nid:
+                    try:
+                        note = mw.col.get_note(nid)
+                        return note.mid
+                    except:
+                        pass
+            return None
+


### PR DESCRIPTION
Hello, Thanks for the addon, I use it quite a lot. 

I created this PR to make it more convenient to configure the default fields for expression/reading and also add some ways to remember past choices : 

The conf will look like this. The first two default_* are things you can change yourself and field_memory is updated when the user use the addon

``` 
{
    "default_expression_field": "Front",
    "default_reading_field": "Reading",
    "field_memory": {
        "Yomitan JP": {
            "expression_field": "Front",
            "reading_field": "Reading"
        }
    },
    "max_entries": 4,
    "reading_handlebar": "reading",
    "yomitan_api_ip": "127.0.0.1",
    "yomitan_api_port": 19633,
    "yomitan_api_timeout": 10
}
``` 